### PR TITLE
use full event when signing with the extension

### DIFF
--- a/src/agent/keys.ts
+++ b/src/agent/keys.ts
@@ -28,11 +28,13 @@ const sign = async event => {
 
   event.pubkey = get(pubkey)
   event.id = getEventHash(event)
-  event.sig = ext
-    ? prop('sig', await ext.signEvent(event))
-    : signEvent(event, get(privkey))
 
-  return event
+  if (ext) {
+    return await ext.signEvent(event)
+  } else {
+    event.sign = signEvent(event, get(privkey))
+    return event
+  }
 }
 
 const getCrypt = () => {


### PR DESCRIPTION
because if the client is building the event with the pubkey A, but the actual key used by the extension is B, using just the `.sig` property of the value returned by `window.nostr.signEvent()` will cause the event to be invalid.