### PR TITLE
Add a "Details" tab to user profile view

### DIFF
--- a/src/views/person/Details.svelte
+++ b/src/views/person/Details.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import cx from "classnames"
+  import {nip05, nip19} from "nostr-tools"
+  import {last} from "ramda"
+  import {toast} from "src/app/ui"
+  import Anchor from "src/partials/Anchor.svelte"
+  import Content from "src/partials/Content.svelte"
+  import Spinner from "src/partials/Spinner.svelte"
+  import {copyToClipboard} from "src/util/html"
+  import {warn} from "src/util/logger"
+  import {stringToColor} from "src/util/misc"
+  import {onMount} from "svelte"
+  import {fly} from "svelte/transition"
+
+  // Re-use the person and nip05 identifier
+  // from the PersonDetail component context
+  export let nip05identifier = null
+  export let person: any = {}
+
+  // local items
+  let nip05ProfileData = null
+  let nip05QueryEndpoint = null
+  let nProfile = null
+  let npub = person?.pubkey ? nip19.npubEncode(person?.pubkey) : null
+
+  // local state
+  let loaded = false
+
+  // controls whether nprofile is displayed.
+  let displayNprofile = false
+
+  onMount(() => {
+    if (nip05identifier) {
+      // get target URI
+      nip05QueryEndpoint = getNip05QueryEndpoint(nip05identifier)
+      // nip05QueryEndpoint = getNip05QueryURI(`NostrVerified.com`)
+
+      // calculate nProfile from NIP05 data, if available
+      nProfile = nip19.nprofileEncode({
+        pubkey: person.pubkey,
+        relays: person?.relays,
+      })
+
+      // fetch data
+      nip05
+        .queryProfile(nip05identifier)
+        .then((data) => {
+          nip05ProfileData = data
+
+          // recalculate nprofile using NIP05 relay data, if specified.
+          // In theory, those *should* be the user's prefered relay set.
+          if (nip05ProfileData?.relays?.length) {
+            nProfile = nip19.nprofileEncode({
+              pubkey: person.pubkey,
+              relays: nip05ProfileData.relays,
+            })
+          }
+        })
+        .catch((err) => {
+          warn("NIP05 profile retrieval failed")
+        })
+        .finally(() => {
+          loaded = true
+        })
+    } else {
+      loaded = true
+    }
+  })
+
+  // Construct NIP05 URL from identifier.
+  function getNip05QueryEndpoint(identifier) {
+    if (!identifier) return null
+
+    let name, domain
+
+    if (identifier.match(/^.*@.*$/)) {
+      [name, domain] = identifier.split("@")
+    } else {
+      // In case of no name (domain-only), mimick the reasonable
+      // (but somewhat questionable) behaviour of nostr-tools/nip05,
+      // which defaults the name value
+      [name, domain] = ["_", identifier]
+    }
+    return `https://${domain}/.well-known/nostr.json?name=${name}`
+  }
+
+  // helper: clipboard & toast
+  function copy(text) {
+    copyToClipboard(text)
+    toast.show("info", `Copied.`)
+  }
+</script>
+
+<div in:fly={{y: 20}}>
+  <Content>
+    <h2 class="text-3xl staatliches my-4">General</h2>
+
+    <div class="">
+      <div class="text-lg font-bold mb-1">Public Key (Hex)</div>
+      <div class="text-sm font-mono">
+        <button
+          class="fa-solid fa-copy cursor-pointer"
+          on:click={() => copy(person?.pubkey)}
+        />
+        {person?.pubkey || "?"}
+      </div>
+    </div>
+
+    <div class="">
+      <div class="text-lg font-bold mb-1">Public Key (npub)</div>
+      <div class="text-sm font-mono">
+        {#if npub}
+          <button
+            class="fa-solid fa-copy cursor-pointer"
+            on:click={() => copy(npub)}
+          />
+        {/if}
+        {person?.pubkey ? nip19.npubEncode(person?.pubkey) : "?"}
+      </div>
+    </div>
+
+    {#if displayNprofile}
+      <div class="">
+        <div class="text-lg font-bold mb-1">nprofile</div>
+        <div class="text-sm font-mono" style="overflow-wrap: anywhere;">
+          {#if nProfile}
+            <button
+              class="fa-solid fa-copy cursor-pointer inline"
+              on:click={() => copy(nProfile)}
+            />
+          {/if}
+          {nProfile || "?"}
+        </div>
+      </div>
+    {/if}
+
+    {#if !loaded}
+      <Spinner delay={10} />
+    {/if}
+
+    {#if loaded && nip05identifier}
+      <h2 class="text-3xl staatliches my-4">NIP05</h2>
+
+      <div class="">
+        <div class="text-lg font-bold mb-1">NIP05 Identifier</div>
+        <div class="text-sm font-mono">
+          {#if nip05identifier}
+            <button
+              class="fa-solid fa-copy cursor-pointer inline"
+              on:click={() => copy(nip05identifier)}
+            />
+          {/if}
+          {nip05identifier || "?"}
+        </div>
+      </div>
+
+      <div class="">
+        <div class="text-lg font-bold mb-1">NIP05 Validation Endpoint</div>
+        <div class="text-sm font-mono">
+          {#if nip05QueryEndpoint}
+            <button
+              class="fa-solid fa-copy cursor-pointer inline"
+              on:click={() => copy(nip05QueryEndpoint)}
+            />
+          {/if}
+
+          {nip05QueryEndpoint || "?"}
+        </div>
+      </div>
+
+      {#if nip05ProfileData}
+        <div class="">
+          <div class="text-lg font-bold mb-2">NIP05 Relay Configuration</div>
+          {#if nip05ProfileData?.relays?.length}
+            <p class="text-sm mb-4 text-light">
+              <i class="fa-solid fa-info-circle" />
+              These relays are advertised by the NIP05 identifier's validation endpoint.
+            </p>
+
+            <div class="grid grid-cols-1 gap-4">
+              {#each nip05ProfileData?.relays as r}
+                <div class="text-sm font-mono">
+                  <div
+                    class={cx(
+                      `bg-dark`,
+                      "rounded border border-l-2 border-solid border-medium shadow flex flex-col justify-between gap-3 py-3 px-6"
+                    )}
+                    style={`border-left-color: ${stringToColor(r)}`}
+                    in:fly={{y: 20}}
+                  >
+                    <div class="flex gap-2 items-center justify-between">
+                      <div class="flex gap-2 items-center text-xl">
+                        <i
+                          class={r.startsWith("wss")
+                            ? "fa fa-lock"
+                            : "fa fa-unlock"}
+                        />
+                        <Anchor type="unstyled" href={`/relays/${btoa(r)}`}>
+                          {last(r.split("://"))}
+                        </Anchor>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {:else}
+            <p class="text-sm mb-4 text-light">
+              <i class="fa-solid fa-info-circle" />
+              No relays are advertised by the NIP05 identifier's validation endpoint.
+            </p>
+          {/if}
+        </div>
+      {:else}
+        <p>
+          <i class="fa-solid fa-warning text-warning mr-2" />Could not fetch
+          NIP05 data.
+        </p>
+      {/if}
+    {/if}
+  </Content>
+</div>

--- a/src/views/person/PersonDetail.svelte
+++ b/src/views/person/PersonDetail.svelte
@@ -15,6 +15,7 @@
   import Notes from "src/views/person/Notes.svelte"
   import Likes from "src/views/person/Likes.svelte"
   import Relays from "src/views/person/Relays.svelte"
+  import Details from 'src/views/person/Details.svelte'
   import user from "src/agent/user"
   import {sampleRelays, getPubkeyWriteRelays} from "src/agent/relays"
   import network from "src/agent/network"
@@ -166,7 +167,7 @@
     </div>
   </div>
 
-  <Tabs tabs={['notes', 'likes', 'relays']} {activeTab} {setActiveTab} />
+  <Tabs tabs={['notes', 'likes', 'relays', 'details']} {activeTab} {setActiveTab} />
 
   {#if activeTab === 'notes'}
   <Notes {pubkey} />
@@ -182,6 +183,8 @@
       Unable to show network for this person.
     </Content>
     {/if}
+  {:else if activeTab === "details"}
+    <Details nip05identifier={person?.verified_as} {person} />
   {/if}
 </Content>
 


### PR DESCRIPTION
This PR proposes the addition of a "Details" tab to the user profile view. 

**Rationale**

A key reason I use Coracle is because it does a great job with the ergonomics around inspecting and managing relays. There is a balance to strike between keeping the UI minimal, and exposing an appropriate amount of Nostr-related technical detail to users. The only place where I kept missing such detail in Coracle is on the user profile view. This new tab attempts to scratch that itch with some basic but useful information alongside user profiles. The NIP05-related information also aims to provide sufficient detail to troubleshoot NIP05 endpoints, and in particular the relay information they might expose.

**Detail**

- show a profile's public key in both hex and npub formats
- display an nprofile, which is constructed on the fly from either the profile's DB relays, or from the NIP05-advertised relays, if the latter is available. **Note**: this feature is disabled with a flag in the component, pending further consideration and/or refinement.
- When a profile's NIP05 identifier is available:
  - show the full NIP05 identifier
  - show the URL of the NIP05 validation endpoint
  - retrieve the NIP05 validation endpoint's response, in order to...
  - display NIP05-advertised relays, if they are configured/available
- copy buttons where useful

Preview (excluding nprofile):

![image](https://user-images.githubusercontent.com/81191656/221385384-8cb4ff5f-4a83-45b6-a5a2-6a755f4abec2.png)
