### PR TITLE
optimize deduplication

### DIFF
--- a/src/agent/pool.ts
+++ b/src/agent/pool.ts
@@ -263,17 +263,20 @@ const subscribe = async (
       return
     }
 
-    const sub = conn.nostr.sub(filter, {id})
+    const sub = conn.nostr.sub(filter, {
+      id,
+      alreadyHaveEvent: (id) => {
+        conn.stats.eventsCount += 1
+        let has = false
+        if (seen.has(id)) has = true
+        seen.add(id)
+        return has
+      }
+    })
 
     sub.on('event', e => {
-      conn.stats.eventsCount += 1
-
-      if (!seen.has(e.id)) {
-        seen.add(e.id)
-
         // Normalize events here, annotate with relay url
         onEvent({...e, seen_on: relay.url, content: e.content || ''})
-      }
     })
 
     sub.on('eose', () => {


### PR DESCRIPTION
This will deduplicate incoming events before parsing them (yes, it skips `JSON.parse()`, which apparently is a slow beast) and verifying the signature.

I was told the performance effects of this are noticeable at naked eye.